### PR TITLE
Aareg-klient

### DIFF
--- a/.nais/dev-fss.json
+++ b/.nais/dev-fss.json
@@ -23,7 +23,7 @@
     "KRR_URL": "https://digdir-krr-proxy.dev.intern.nav.no",
     "KRR_AUDIENCE":"dev-gcp:team-rocket:digdir-krr-proxy",
     "AAREG_URL": "https://aareg-services-q1.dev.intern.nav.no/api",
-    "AAREG_AUDIENCE": "dev-fss:arbeidsforhold:aareg-services-q1"
+    "AAREG_AUDIENCE": "dev-fss:arbeidsforhold:aareg-services-nais-q1"
   },
   "minReplicas": "1",
   "maxReplicas": "2"

--- a/.nais/dev-fss.json
+++ b/.nais/dev-fss.json
@@ -21,7 +21,9 @@
     "KODEVERK_URL": "https://kodeverk.dev.adeo.no/api/v1/kodeverk",
     "EREG_URL": "https://ereg-services-q1.dev.intern.nav.no/api",
     "KRR_URL": "https://digdir-krr-proxy.dev.intern.nav.no",
-    "KRR_AUDIENCE":"dev-gcp:team-rocket:digdir-krr-proxy"
+    "KRR_AUDIENCE":"dev-gcp:team-rocket:digdir-krr-proxy",
+    "AAREG_URL": "https://aareg-services-q1.dev.intern.nav.no/api",
+    "AAREG_AUDIENCE": "dev-fss:arbeidsforhold:aareg-services-q1"
   },
   "minReplicas": "1",
   "maxReplicas": "2"

--- a/.nais/prod-fss.json
+++ b/.nais/prod-fss.json
@@ -19,7 +19,9 @@
     "KODEVERK_URL": "https://kodeverk.intern.nav.no/api/v1/kodeverk",
     "EREG_URL": "https://ereg-services.intern.nav.no/api",
     "KRR_URL": "https://digdir-krr-proxy.intern.nav.no",
-    "KRR_AUDIENCE":"prod-gcp:team-rocket:digdir-krr-proxy"
+    "KRR_AUDIENCE":"prod-gcp:team-rocket:digdir-krr-proxy",
+    "AAREG_URL": "https://aareg-services.intern.nav.no/api",
+    "AAREG_AUDIENCE": "prod-fss:arbeidsforhold:aareg-services"
   },
   "minReplicas": "2",
   "maxReplicas": "4"

--- a/.nais/prod-fss.json
+++ b/.nais/prod-fss.json
@@ -21,7 +21,7 @@
     "KRR_URL": "https://digdir-krr-proxy.intern.nav.no",
     "KRR_AUDIENCE":"prod-gcp:team-rocket:digdir-krr-proxy",
     "AAREG_URL": "https://aareg-services.intern.nav.no/api",
-    "AAREG_AUDIENCE": "prod-fss:arbeidsforhold:aareg-services"
+    "AAREG_AUDIENCE": "prod-fss:arbeidsforhold:aareg-services-nais"
   },
   "minReplicas": "2",
   "maxReplicas": "4"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Interne henvendelser kan sendes via Slack i kanalen #team_digisos.
 Midlertidig proxy for sosialhjelp-soknad-api i sbs-clustre.
 `GET /proxy/krr/rest/v1/person`
 
+### Aareg
+Midlertidig proxy for sosialhjelp-soknad-api i sbs-clustre.
+`GET /proxy/aareg/v1/arbeidstaker/arbeidsforhold`
+
 ### Ping
 `OPTIONS /ping`
 

--- a/src/main/kotlin/no/nav/sosialhjelp/sosialhjelpfssproxy/aareg/AaregClient.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/sosialhjelpfssproxy/aareg/AaregClient.kt
@@ -1,0 +1,57 @@
+package no.nav.sosialhjelp.sosialhjelpfssproxy.aareg
+
+import no.nav.sosialhjelp.sosialhjelpfssproxy.common.Client
+import no.nav.sosialhjelp.sosialhjelpfssproxy.tokendings.TokendingsService
+import no.nav.sosialhjelp.sosialhjelpfssproxy.utils.HeaderUtils.BEARER
+import no.nav.sosialhjelp.sosialhjelpfssproxy.utils.HeaderUtils.HEADER_CALL_ID
+import no.nav.sosialhjelp.sosialhjelpfssproxy.utils.HeaderUtils.HEADER_NAV_PERSONIDENT
+import no.nav.sosialhjelp.sosialhjelpfssproxy.utils.HeaderUtils.getCallId
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders.AUTHORIZATION
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitBodyOrNull
+import org.springframework.web.reactive.function.server.ServerRequest
+
+@Component
+class AaregClient(
+    webClientBuilder: WebClient.Builder,
+    @Value("\${fss-proxy.aareg_url}") private val aaregUrl: String,
+    @Value("\${fss-proxy.aareg_audience}") private val aaregAudience: String,
+    private val tokendingsService: TokendingsService
+) : Client {
+
+    private val aaregWebClient = webClientBuilder.baseUrl(aaregUrl).build()
+
+    suspend fun getArbeidsforhold(ident: String, request: ServerRequest): List<ArbeidsforholdDto>? {
+        return aaregWebClient.get()
+            .uri {
+                it
+                    .path("/v1/arbeidstaker/arbeidsforhold")
+                    .queryParam("sporingsinformasjon", request.queryParam("sporingsinformasjon"))
+                    .queryParam("regelverk", request.queryParam("regelverk"))
+                    .queryParam("ansettelsesperiodeFom", request.queryParam("ansettelsesperiodeFom"))
+                    .queryParam("ansettelsesperiodeTom", request.queryParam("ansettelsesperiodeTom"))
+                    .build()
+            }
+            .accept(APPLICATION_JSON)
+            .header(AUTHORIZATION, BEARER + tokenXtoken(request))
+            .header(HEADER_CALL_ID, getCallId(request))
+            .header(HEADER_NAV_PERSONIDENT, ident)
+            .retrieve()
+            .awaitBodyOrNull()
+    }
+
+    override suspend fun ping() {
+        aaregWebClient.options()
+            .uri("/ping")
+            .header(HEADER_CALL_ID, getCallId())
+            .retrieve()
+            .awaitBodyOrNull<Any>()
+    }
+
+    private suspend fun tokenXtoken(request: ServerRequest): String {
+        return tokendingsService.exchangeToken(request, aaregAudience)
+    }
+}

--- a/src/main/kotlin/no/nav/sosialhjelp/sosialhjelpfssproxy/aareg/AaregHandler.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/sosialhjelpfssproxy/aareg/AaregHandler.kt
@@ -1,0 +1,22 @@
+package no.nav.sosialhjelp.sosialhjelpfssproxy.aareg
+
+import no.nav.sosialhjelp.sosialhjelpfssproxy.utils.HeaderUtils.getNavPersonident
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.bodyValueAndAwait
+import org.springframework.web.reactive.function.server.buildAndAwait
+
+@Component
+class AaregHandler(
+    private val aaregClient: AaregClient
+) {
+    suspend fun getArbeidsforhold(request: ServerRequest): ServerResponse {
+        val ident = getNavPersonident(request)
+        val arbeidsforhold = aaregClient.getArbeidsforhold(ident, request)
+        return arbeidsforhold
+            ?.let { ServerResponse.ok().contentType(MediaType.APPLICATION_JSON).bodyValueAndAwait(it) }
+            ?: ServerResponse.notFound().buildAndAwait()
+    }
+}

--- a/src/main/kotlin/no/nav/sosialhjelp/sosialhjelpfssproxy/aareg/AaregRouter.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/sosialhjelpfssproxy/aareg/AaregRouter.kt
@@ -1,0 +1,15 @@
+package no.nav.sosialhjelp.sosialhjelpfssproxy.aareg
+
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.coRouter
+
+@Component
+class AaregRouter(
+    private val aaregHandler: AaregHandler
+) {
+    fun aaregRoutes() = coRouter {
+        path("/aareg").nest {
+            GET("/v1/arbeidstaker/arbeidsforhold", aaregHandler::getArbeidsforhold)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/sosialhjelp/sosialhjelpfssproxy/aareg/ArbeidsforholdDto.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/sosialhjelpfssproxy/aareg/ArbeidsforholdDto.kt
@@ -1,0 +1,44 @@
+package no.nav.sosialhjelp.sosialhjelpfssproxy.aareg
+
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import java.time.LocalDate
+
+data class ArbeidsforholdDto(
+    val ansettelsesperiode: AnsettelsesperiodeDto?,
+    val arbeidsavtaler: List<ArbeidsavtaleDto>?,
+    val arbeidsforholdId: String?,
+    val arbeidsgiver: OpplysningspliktigArbeidsgiverDto?,
+    val arbeidstaker: PersonDto?
+)
+
+data class AnsettelsesperiodeDto(
+    val periode: PeriodeDto
+)
+
+data class ArbeidsavtaleDto(
+    val stillingsprosent: Double
+)
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = OrganisasjonDto::class, name = "Organisasjon"),
+    JsonSubTypes.Type(value = PersonDto::class, name = "Person"),
+)
+sealed class OpplysningspliktigArbeidsgiverDto()
+
+data class OrganisasjonDto(
+    val organisasjonsnummer: String?,
+    val type: String?
+) : OpplysningspliktigArbeidsgiverDto()
+
+data class PersonDto(
+    val offentligIdent: String,
+    val aktoerId: String,
+    val type: String?
+) : OpplysningspliktigArbeidsgiverDto()
+
+data class PeriodeDto(
+    val fom: LocalDate,
+    val tom: LocalDate?
+)

--- a/src/main/kotlin/no/nav/sosialhjelp/sosialhjelpfssproxy/proxy/ProxyRouter.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/sosialhjelpfssproxy/proxy/ProxyRouter.kt
@@ -1,5 +1,6 @@
 package no.nav.sosialhjelp.sosialhjelpfssproxy.proxy
 
+import no.nav.sosialhjelp.sosialhjelpfssproxy.aareg.AaregRouter
 import no.nav.sosialhjelp.sosialhjelpfssproxy.configuration.FrontendErrorMessage
 import no.nav.sosialhjelp.sosialhjelpfssproxy.ereg.EregRouter
 import no.nav.sosialhjelp.sosialhjelpfssproxy.exceptions.ServiceException
@@ -22,7 +23,8 @@ class ProxyRouter(
     private val norgRouter: NorgRouter,
     private val kodeverkRouter: KodeverkRouter,
     private val eregRouter: EregRouter,
-    private val krrRouter: KrrRouter
+    private val krrRouter: KrrRouter,
+    private val aaregRouter: AaregRouter,
 ) {
     companion object {
         private val log by logger()
@@ -34,6 +36,7 @@ class ProxyRouter(
             add(kodeverkRouter.kodeverkRoutes())
             add(eregRouter.eregRoutes())
             add(krrRouter.krrRoutes())
+            add(aaregRouter.aaregRoutes())
             filter { serverRequest, next ->
                 try {
                     tilgangskontrollService.verifyToken(serverRequest)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,8 @@ fss-proxy:
   ereg_url: ${EREG_URL}
   krr_url: ${KRR_URL}
   krr_audience: ${KRR_AUDIENCE}
+  aareg_url: ${AAREG_URL}
+  aareg_audience: ${AAREG_AUDIENCE}
 
 # Prometheus
 management:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -7,3 +7,5 @@ fss-proxy:
   ereg_url: https://ereg/
   krr_url: https://krr/
   krr_audience: dummyAudience
+  aareg_url: http://aareg/
+  aareg_audience: aaregAudience


### PR DESCRIPTION
Ny proxy for aareg (siden ingresser ikke kan nås fra sbs)


Todos:
- [x] Skaffe tilgang til aareg-services for `sosialhjelp-fss-proxy` i dev-fss og prod-fss.