### PR TITLE
info om at repoet arkiveres

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Dette repoet er arkivert, og appen er skrudd av ettersom den ikke trengs lengre.
+
 # sosialhjelp-fss-proxy
 Proxy-app for å nå tjenester on-prem fra GCP (med tokenX)
 


### PR DESCRIPTION
Har gått over til å konsumere aareg og krr direkte i sosialhjelp-soknad-api. Da kan vi arkivere repoet og skru av appen